### PR TITLE
Compatibility update for Time.c

### DIFF
--- a/packetcrypt-sys/packetcrypt/src/Time.c
+++ b/packetcrypt-sys/packetcrypt/src/Time.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: (LGPL-2.1-only OR LGPL-3.0-only)
  */
 #define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
 
 #include "Time.h"
 


### PR DESCRIPTION
define _GNU_SOURCE to workaround warnings on Solaris and AIX