### PR TITLE
Fix issue affecting accouncement mining with armhf archictecture

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -289,12 +289,12 @@ fn submit_to_pool(p: &Pool, ann_struct: &AnnResult, now: u64) {
     let parent_block_height = ann_struct.ann.parent_block_height();
     let handler = {
         let pm = p.m.lock().unwrap();
-        let hcount = pm.handlers.len();
+        let hcount = pm.handlers.len() as u64;
         if hcount == 0 {
             // no handlers for this pool yet
             return;
         }
-        Arc::clone(&pm.handlers[(ann_struct.dedup_hash as usize) % hcount])
+        Arc::clone(&pm.handlers[(ann_struct.dedup_hash as u64 % hcount) as usize])
     };
     let mut tip = handler.tip.lock().unwrap();
     match tip.parent_block_height.cmp(&parent_block_height) {


### PR DESCRIPTION
# Description

With a Raspberry b+, I've encountered the following warning message when mining announcements:

```
1611506372 WARN annmine.rs:432 [6] handler [http://[REDACTED]/submit] replied with no result [{"warn":[],"error":["submit elsewhere"],"result":null}]                                                    
1611506374 WARN annmine.rs:432 [7] handler [http://[REDACTED]/submit] replied with no result [{"warn":[],"error":["submit elsewhere"],"result":null}]                                                    
1611506374 WARN annmine.rs:432 [8] handler [http://[REDACTED]/submit] replied with no result [{"warn":[],"error":["submit elsewhere"],"result":null}]                                                    
1611506375 WARN annmine.rs:432 [9] handler [http://[REDACTED]/submit] replied with no result [{"warn":[],"error":["submit elsewhere"],"result":null}]
```

After applying the submitted changes:

No more worrying warning messages!