### PR TITLE
Remove build flags raising some errors on execution

### DIFF
--- a/packetcrypt-sys/build.rs
+++ b/packetcrypt-sys/build.rs
@@ -122,8 +122,6 @@ fn main() {
         .file("packetcrypt/src/Work.c")
         .file("packetcrypt/src/UdpGso.c")
         .out_dir(dst.join("lib"))
-        .flag_if_supported("-march=native")
-        .flag_if_supported("-mtune=native")
         .flag("-O2")
         .compile("libpacketcrypt.a");
 


### PR DESCRIPTION
# Description

Running announcement mining would raise the following error:

```
[1]    697658 illegal hardware instruction (core dumped)  
```

These changes prevent this error.