### PR TITLE
Pass portable feature flag to cargo build

### DIFF
--- a/contrib/github-actions/build-linux-binary.sh
+++ b/contrib/github-actions/build-linux-binary.sh
@@ -2,7 +2,7 @@
 
 function build() {
   cd "${GITHUB_WORKSPACE}" || exit
-  cargo build --release --features jemalloc --target=x86_64-unknown-linux-musl
+  cargo build --release --features portable --target=x86_64-unknown-linux-musl
 
   mkdir "${GITHUB_WORKSPACE}/bin"
 

--- a/contrib/github-actions/build-macos-package.sh
+++ b/contrib/github-actions/build-macos-package.sh
@@ -2,7 +2,7 @@
 
 function build() {
   cd "${GITHUB_WORKSPACE}" || exit
-  cargo build --release --features jemalloc
+  cargo build --release --features portable
 
   mkdir "${GITHUB_WORKSPACE}/bin"
   cp "${GITHUB_WORKSPACE}/target/release/packetcrypt" "${GITHUB_WORKSPACE}/bin"

--- a/contrib/github-actions/build-windows-package.sh
+++ b/contrib/github-actions/build-windows-package.sh
@@ -2,7 +2,7 @@
 
 function build() {
   cd "${GITHUB_WORKSPACE}" || exit
-  cargo build --release --target x86_64-pc-windows-gnu
+  cargo build --release --features portable --target x86_64-pc-windows-gnu
 
   mkdir ./bin
 


### PR DESCRIPTION
# Description

The `--feature portable` is passed to `cargo build` instruction on new tag push so that architecture-specific compilation optimizations would not prevent running statically pre-compiled binaries.