### PR TITLE
fix(main.rs): add fallback version string for out-of-tree builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ async fn async_main(matches: clap::ArgMatches<'_>) -> Result<()> {
 }
 
 fn version() -> &'static str {
-    let out = git_version::git_version!(args = ["--tags", "--dirty=-dirty"]);
+    let out = git_version::git_version!(args = ["--tags", "--dirty=-dirty", "--broken"], fallback="out-of-tree");
     if let Some(v) = out.strip_prefix("packetcrypt-v") {
         &v
     } else {


### PR DESCRIPTION
This commit changes the behavior of the detection mechanism to tag packetcrypt_rs using the latest git tag.
If no tag is found/git is broken, the build will still succeed.

- Broken gits: version string is "broken"
- No git: version string is "out-of-tree"