### PR TITLE
Fixed bugs in miner

### DIFF
--- a/packetcrypt-annmine/src/annminer.rs
+++ b/packetcrypt-annmine/src/annminer.rs
@@ -43,7 +43,6 @@ pub unsafe extern "C" fn on_ann_found(vctx: *mut c_void, ann: *mut u8) {
 }
 
 pub fn new(miner_id: u32, workers: usize) -> (AnnMiner, UnboundedReceiver<AnnResult>) {
-    packetcrypt_sys::init();
     let (send_ann, recv_ann) = tokio::sync::mpsc::unbounded_channel();
     let mut cbc = Box::new(CallbackCtx { send_ann });
     let ptr = (&mut *cbc as *mut CallbackCtx) as *mut c_void;

--- a/packetcrypt-blkmine/src/blkmine.rs
+++ b/packetcrypt-blkmine/src/blkmine.rs
@@ -382,6 +382,21 @@ impl packetcrypt_sprayer::OnAnns for BlkMine {
             indexes.push(ai.index);
             height_work = Some(ai.hw);
         }
+        if let Some(hw) = height_work {
+            trace!(
+                "Batch of {} anns {} @ {}",
+                indexes.len(),
+                hw.block_height,
+                packetcrypt_sys::difficulty::tar_to_diff(hw.work)
+            );
+            on_anns(
+                self,
+                AnnChunk {
+                    anns,
+                    indexes: &indexes[..],
+                },
+            );
+        }
     }
 }
 

--- a/packetcrypt-sys/packetcrypt/src/ProofTree.c
+++ b/packetcrypt-sys/packetcrypt/src/ProofTree.c
@@ -37,7 +37,7 @@ void ProofTree_prepare2(ProofTree_t* pt, uint64_t totalAnns)
 }
 
 ProofTree_Proof_t* ProofTree_mkProof(ProofTree_t* pt, const uint64_t annNumbers[4]) {
-    ProofTree_Proof_t* out = malloc(sizeof(ProofTree_Proof_t*));
+    ProofTree_Proof_t* out = malloc(sizeof(ProofTree_Proof_t));
     assert(out);
     int size = 0;
     out->data = PacketCryptProof_mkProof(&size, &pt->tree, annNumbers);

--- a/packetcrypt-sys/packetcrypt/src/Validate.c
+++ b/packetcrypt-sys/packetcrypt/src/Validate.c
@@ -156,7 +156,7 @@ int Validate_checkBlock(const PacketCrypt_HeaderAndProof_t* hap,
                         uint32_t blockHeight,
                         uint32_t shareTarget,
                         const PacketCrypt_Coinbase_t* coinbaseCommitment,
-                        const uint8_t blockHashes[static PacketCrypt_NUM_ANNS * 32],
+                        const uint8_t blockHashes[PacketCrypt_NUM_ANNS * 32],
                         uint8_t workHashOut[static 32],
                         PacketCrypt_ValidateCtx_t* vctx)
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ macro_rules! get_num {
 async fn async_main(matches: clap::ArgMatches<'_>) -> Result<()> {
     leak_detect().await?;
     exiter().await?;
+    packetcrypt_sys::init();
     util::setup_env(matches.occurrences_of("v")).await?;
     if let Some(ann) = matches.subcommand_matches("ann") {
         // ann miner


### PR DESCRIPTION
These 4 patches fix several bugs in the miner:
1. only the first announcement in a jumbo frame received in the non-GSO path was handled
2. the final sequence of announcements with equal properties (height, target) in a received buffer was discarded
3. a buffer allocated for the proof structure was too small causing memory corruption, an argument declaration caused a null check to be dropped when compiling with clang, causing segmentation faults in the blockminer
4. libsodium needs to be initialized for optimal performance (should do this for all operations, not just the announcement miner)