### PR TITLE
Bench blk command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,10 +1102,12 @@ dependencies = [
  "packetcrypt-sprayer",
  "packetcrypt-sys",
  "packetcrypt-util",
+ "rand 0.8.4",
  "rayon",
  "reqwest",
  "serde",
  "serde_json",
+ "sodiumoxide",
  "tokio",
 ]
 
@@ -1153,7 +1166,7 @@ dependencies = [
  "hex",
  "log",
  "nix",
- "rand",
+ "rand 0.7.3",
  "regex",
  "reqwest",
  "serde",
@@ -1307,11 +1320,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1321,7 +1346,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1330,7 +1365,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -1339,7 +1383,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/packetcrypt-blkmine/Cargo.toml
+++ b/packetcrypt-blkmine/Cargo.toml
@@ -20,3 +20,5 @@ hex-literal = "0.3"
 reqwest = { version = "0.10", features = ["stream"], default-features = false }
 hex = "0.4"
 rayon = "1.5"
+rand = "0.8"
+sodiumoxide = { git = "https://github.com/cjdelisle/sodiumoxide", rev = "76dc0e6e587b8c8a4bb193ebba9f8ae8f090b81b", default-features = false, features = ["std"] }

--- a/packetcrypt-blkmine/src/bench.rs
+++ b/packetcrypt-blkmine/src/bench.rs
@@ -1,0 +1,115 @@
+use crate::blkminer::BlkMiner;
+use anyhow::Result;
+use rand::Rng;
+use sodiumoxide::crypto::stream::chacha20;
+use std::fmt::{Display, Formatter};
+use std::io::{self, Write};
+use std::ops::{AddAssign, Div};
+use std::thread;
+use std::time::Duration;
+
+pub struct Bencher {
+    repeats: u32,
+    sampling: Duration,
+}
+
+impl Bencher {
+    pub fn new(repeats: u32, sampling_ms: u64) -> Self {
+        Self {
+            repeats,
+            sampling: Duration::from_millis(sampling_ms),
+        }
+    }
+
+    pub async fn bench_blk(&self, max_mem: u64, threads: u32) -> Result<()> {
+        println!("Starting benchmark");
+        println!("mem: {}MB, threads: {}", max_mem / 1024 / 1024, threads);
+        let block_miner = start_bench_blk(max_mem, threads)?;
+
+        // we will just call this several times, and return their arithmetic average.
+        // there probably are more advanced/accurate algorithms, like discarding the outliers,
+        // using other kinds of average, etc., but we'll keep it simple.
+        let mut result = BenchBlk::default();
+        for i in 1..=self.repeats {
+            thread::sleep(self.sampling);
+            let partial = BenchBlk {
+                hashes_per_second: block_miner.hashes_per_second() as f64,
+                // other monitoring points in the future?
+            };
+            println!("{:2}. result: {}", i, partial);
+            result += partial;
+        }
+        println!("average: {}", result / self.repeats);
+        block_miner.stop();
+        Ok(())
+    }
+}
+
+/// Assembles all the infrastructure needed to block mining, and starts it.
+fn start_bench_blk(max_mem: u64, threads: u32) -> Result<BlkMiner> {
+    let block_miner = BlkMiner::new(max_mem, threads)?;
+    println!("created miner");
+
+    let key = chacha20::gen_key();
+    let mut nonce = chacha20::Nonce::from_slice(&[0; 8]).unwrap();
+    let mut ann = chacha20::stream(1024, &nonce, &key);
+    let total_entries = block_miner.max_anns;
+    for i in 0..total_entries {
+        print!(
+            "\rinserting announcements... {:.1}%",
+            i as f64 / total_entries as f64 * 100.0
+        );
+        io::stdout().flush().unwrap();
+
+        nonce.increment_le_inplace();
+        chacha20::stream_xor_inplace(&mut ann, &nonce, &key);
+        block_miner.put_ann(i, &ann);
+    }
+    println!();
+
+    println!("preparing lookup table...");
+    struct Entry {
+        index: u32,
+        random: u32,
+    }
+    let mut r = rand::thread_rng();
+    let mut lookup = (0..total_entries)
+        .map(|index| Entry {
+            index,
+            random: r.gen(),
+        })
+        .collect::<Vec<_>>();
+    lookup.sort_unstable_by_key(|e| e.random);
+    let lookup = lookup.into_iter().map(|e| e.index).collect::<Vec<_>>();
+
+    println!("starting mining");
+    block_miner.mine(&[0u8, 80], &lookup, 0x03000001, 0xc001); // 0xc001 is cool :)
+    Ok(block_miner)
+}
+
+#[derive(Default)]
+struct BenchBlk {
+    hashes_per_second: f64,
+}
+
+impl AddAssign for BenchBlk {
+    fn add_assign(&mut self, rhs: Self) {
+        self.hashes_per_second += rhs.hashes_per_second
+    }
+}
+
+impl Div<u32> for BenchBlk {
+    type Output = BenchBlk;
+
+    fn div(self, rhs: u32) -> Self::Output {
+        BenchBlk {
+            hashes_per_second: self.hashes_per_second / rhs as f64,
+        }
+    }
+}
+
+impl Display for BenchBlk {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.2} hashes/sec", self.hashes_per_second)
+    }
+}

--- a/packetcrypt-blkmine/src/bench.rs
+++ b/packetcrypt-blkmine/src/bench.rs
@@ -1,5 +1,6 @@
 use crate::blkminer::BlkMiner;
 use anyhow::Result;
+use packetcrypt_util::util;
 use rand::Rng;
 use sodiumoxide::crypto::stream::chacha20;
 use std::fmt::{Display, Formatter};
@@ -110,6 +111,6 @@ impl Div<u32> for BenchBlk {
 
 impl Display for BenchBlk {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:.2} hashes/sec", self.hashes_per_second)
+        write!(f, "{}e/s", util::big_number(self.hashes_per_second))
     }
 }

--- a/packetcrypt-blkmine/src/lib.rs
+++ b/packetcrypt-blkmine/src/lib.rs
@@ -2,4 +2,5 @@ mod blkminer;
 mod downloader;
 mod prooftree;
 
+pub mod bench;
 pub mod blkmine;

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,10 @@ async fn async_main(matches: clap::ArgMatches<'_>) -> Result<()> {
 }
 
 fn version() -> &'static str {
-    let out = git_version::git_version!(args = ["--tags", "--dirty=-dirty", "--broken"], fallback="out-of-tree");
+    let out = git_version::git_version!(
+        args = ["--tags", "--dirty=-dirty", "--broken"],
+        fallback = "out-of-tree"
+    );
     if let Some(v) = out.strip_prefix("packetcrypt-v") {
         &v
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,11 +145,6 @@ async fn bench_blk(max_mem: u64, threads: u32) -> Result<()> {
     bencher.bench_blk(max_mem, threads).await
 }
 
-/// Benchmarks the tree construction.
-async fn bench_tree() -> Result<()> {
-    todo!()
-}
-
 macro_rules! get_strs {
     ($m:ident, $s:expr) => {
         if let Some(x) = $m.values_of($s) {
@@ -282,8 +277,6 @@ async fn async_main(matches: clap::ArgMatches<'_>) -> Result<()> {
             let max_mem = get_num!(blk, "memorysizemb", u64) * 1024 * 1024;
             let threads = get_num!(blk, "threads", u32);
             bench_blk(max_mem, threads).await?;
-        } else if let Some(_) = bench.subcommand_matches("tree") {
-            bench_tree().await?;
         }
     }
     Ok(())
@@ -566,10 +559,6 @@ async fn main() -> Result<()> {
                             .default_value(&cpus_str)
                             .takes_value(true),
                     )
-                )
-                .subcommand(
-                    SubCommand::with_name("tree")
-                        .about("Benchmark the time to construct a typical tree")
                 )
         )
         .get_matches();


### PR DESCRIPTION
I've mplemented a new command, which benchmarks the encryption hashes per second of a block mining.

```
❯ packetcrypt bench blk
Starting benchmark
mem: 4096MB, threads: 12
created miner
inserting announcements... 100.0%
preparing lookup table...
starting mining
 1. result: 109 Ke/s
 2. result: 92 Ke/s
 3. result: 105 Ke/s
 4. result: 109 Ke/s
 5. result: 105 Ke/s
 6. result: 106 Ke/s
 7. result: 106 Ke/s
 8. result: 101 Ke/s
 9. result: 107 Ke/s
10. result: 103 Ke/s
average: 104 Ke/s
```