### PR TITLE
Ignore "invalid" domain in announcement uploader

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -278,6 +278,17 @@ fn submit_anns(
     if tip.anns.len() == 0 {
         return;
     }
+    use reqwest::Url;
+    if let Ok(url) = Url::parse(&h.url) {
+        if url.scheme() == "http" || url.scheme() == "https" {
+            if let Some(domain) = url.domain() {
+                if domain == "invalid" {
+                    p.rejected_anns.fetch_add(tip.anns.len(), Ordering::Relaxed);
+                    return;
+                }
+            }
+        }
+    }
     let mut queue = h.queue.lock().unwrap();
     trace!("Queue {} anns at {} for {}, {} batches currently queued", tip.anns.len(), tip.parent_block_height, h.url, queue.len());
     if queue.len() >= UPLOAD_CHANNEL_LEN {


### PR DESCRIPTION
This patch allows pools to specify announcement handlers using the "invalid" domain to indicate that they do not wish to receive any announcement destined for a specific handler. This can be used as a method to manage the bandwidth on a pool that can not affect the miner difficulty, without the errors caused by other invalid or dead handler addresses.

The `invalid` TLD is reserved by the IETF in RFC 2606 as a domain name that may not be installed as a top-level domain in the DNS of the Internet. This makes it a good candidate for the intended purpose as it will both ensure that there are no unintended matches, and also that the use in miners without this patch will still result in the desired effect (announcements not being sent anywhere).

I don't really like to make pool-specific changes in the code, but this seems like a better idea than recommending to just suppress error messages entirely, and might be useful for others.