### PR TITLE
Consolidate "Install Guide" commands into a single line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,17 +30,13 @@ First install rust if you haven't, see: [rustup](https://rustup.rs/)
 
 Step 1: Copy and run the following command
 
-    sudo apt-get update && sudo apt install gcc git && sudo apt install curl && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && sudo apt install make && mkdir ~/packet && cd ~/packet && git clone https://github.com/cjdelisle/packetcrypt_rs && cd packetcrypt_rs
+    sudo apt-get update && sudo apt-get install gcc git curl make clang && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && mkdir ~/packet && cd ~/packet && git clone https://github.com/cjdelisle/packetcrypt_rs && cd packetcrypt_rs
 
-Step 2: Copy and run the following command
-
-    sudo apt install clang
-
-Step 2.5(Optional). If you were using a gcc build then please copy and run the following command
+Step 1.5(Optional). If you were using a gcc build then please copy and run the following command
 
     cargo clean
 
-Step 3: Copy and run the following command
+Step 2: Copy and run the following command
 
     CC=clang cargo build --release
 


### PR DESCRIPTION
Changed the "Install with CLANG build" guide to have all installs in a single command rather than separate. Looks more clean this way and should work the same way?