### PR TITLE
Fix mineOld not able to be changed 

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -168,7 +168,7 @@ fn update_work_cycle(am: &AnnMine, p: &Arc<Pool>, update: PoolUpdate) -> Vec<Arc
     };
 
     if p.primary {
-    	pm.currently_mining = top - mine_old;
+        pm.currently_mining = top - mine_old;
     }
 
     // We're synced to the tip, begin mining (or start mining new anns)

--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -160,12 +160,16 @@ fn update_work_cycle(am: &AnnMine, p: &Arc<Pool>, update: PoolUpdate) -> Vec<Arc
         top = max(bi.header.height, top);
         pm.recent_work[(bi.header.height as usize) % RECENT_WORK_BUF] = Some(bi);
     }
+
     let mine_old = if am.cfg.mine_old_anns > -1 {
         am.cfg.mine_old_anns
     } else {
         update.conf.mine_old_anns as i32
     };
-    pm.currently_mining = max(pm.currently_mining, top - mine_old);
+
+    if p.primary {
+    	pm.currently_mining = top - mine_old;
+    }
 
     // We're synced to the tip, begin mining (or start mining new anns)
     let job = if let Some(x) = pm.recent_work[(pm.currently_mining as usize) % RECENT_WORK_BUF] {


### PR DESCRIPTION
If pools fail to find a block for quite some time, the chances of them having a slab devoid of mature anns increases and the chances of finding a block decreases. In a chain stall, restarting a pool and losing mature anns may mean the slab will fill with useless anns and the pool will end up stuck because the only way for anns to mature is for the chain to advance.

In those situations, increasing mineOld for annminers to supply fresh mature anns is the only way to start mining blocks again.
Pools can't currently do that because the annminer code doesn't allow this. This fixes the issue.

This should help pool operators handle shortages better in the future without having to use privately generated anns at custom mineOlds.