### PR TITLE
goodrate = 0% for unreachable pools

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -539,7 +539,7 @@ async fn stats_loop(am: &AnnMine) {
                     ((if total > 0 {
                         accepted as f32 / total as f32
                     } else {
-                        1.0
+                        0.0
                     }) * 100.0) as u32,
                 ));
             }


### PR DESCRIPTION
IMO, if a pool is down/unreachable, goodrate should be logged as 0% rather than 100%.