### PR TITLE
Fixed work tip height detection

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -214,7 +214,6 @@ fn update_work_cycle(am: &AnnMine, p: &Arc<Pool>, update: PoolUpdate) -> Vec<Arc
         pm.handlers = new_handlers;
     }
 
-    let mut top = 0;
     for bi in update.update_blocks {
         if let Some(rw) = pm.recent_work[(bi.header.height as usize) % RECENT_WORK_BUF].as_ref() {
             if rw.header.height > bi.header.height {
@@ -222,8 +221,14 @@ fn update_work_cycle(am: &AnnMine, p: &Arc<Pool>, update: PoolUpdate) -> Vec<Arc
                 continue;
             }
         }
-        top = max(bi.header.height, top);
         pm.recent_work[(bi.header.height as usize) % RECENT_WORK_BUF] = Some(bi);
+    }
+
+    let mut top = 0;
+    for opt in pm.recent_work {
+        if let Some(rw) = opt {
+            top = max(rw.header.height, top);
+        }
     }
 
     let mine_old = if am.cfg.mine_old_anns > -1 {


### PR DESCRIPTION
When a change in pool annhandler configuration is detected by the announcement miner, the update_work_cycle function is invoked without any update_blocks. In the old situation this would result in the top variable remaining at 0 and the announcement miner potentially selecting an incorrect slot from recent_work to start mining, resulting in invalid or outdated announcements being generated until the next block is discovered. This PR fixes that by selecting the best block height from the recent_work set instead of the (possibly empty) update_blocks.