### PR TITLE
Fixed annminer bug/feature that would prevent announcements with lower height than previous batch from being sent to handler

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -345,29 +345,18 @@ fn submit_to_pool(p: &Pool, ann_struct: &AnnResult, now: u64) {
         Arc::clone(&pm.handlers[(ann_struct.dedup_hash as u64 % hcount) as usize])
     };
     let mut tip = handler.tip.lock().unwrap();
-    match tip.parent_block_height.cmp(&parent_block_height) {
-        std::cmp::Ordering::Greater => {
-            debug!(
-                "Miner produced an old announcement, want parent_block_height {} got {}",
-                tip.parent_block_height, parent_block_height
-            );
-            return;
-        }
-        std::cmp::Ordering::Less => {
-            // this prints for each handler
-            trace!(
-                "New block number {} -> {}",
-                tip.parent_block_height,
-                parent_block_height
-            );
-            submit_anns(
-                p,
-                &handler,
-                &mut *tip,
-                parent_block_height,
-            );
-        }
-        std::cmp::Ordering::Equal => (),
+    if tip.parent_block_height != parent_block_height {
+        trace!(
+            "New block number {} -> {}",
+            tip.parent_block_height,
+            parent_block_height
+        );
+        submit_anns(
+            p,
+            &handler,
+            &mut *tip,
+            parent_block_height,
+        );
     }
 
     tip.anns.push(ann_struct.ann.clone());


### PR DESCRIPTION
This patch removes an old feature in the announcement miner that would drop announcement batches with a height lower than the previous batch sent to that same handler. This feature prevents mining pools from dynamically altering the mineOld setting as a way to optimize their announcement set, possibly complicating recovery from a chain stall when insufficient mature announcements are available.

A quick test did not show side effects other than the intended behavior. Since all mining threads are halted for mining work changes, and the announcement are placed directly in a queue in the miner callback, there should be no reordering issues between miner threads, out-of-order announcements would only appear as a result of changed mining instructions from the pool.