### PR TITLE
Prefer reuse of recently used uploader threads to improve connection reuse

### DIFF
--- a/packetcrypt-annmine/src/annmine.rs
+++ b/packetcrypt-annmine/src/annmine.rs
@@ -11,8 +11,7 @@ use std::cmp::max;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, Condvar};
 use std::collections::VecDeque;
 use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver};
 use serde::{Deserialize};
@@ -27,10 +26,15 @@ struct AnnBatch {
     anns: Vec<PacketCryptAnn>,
 }
 
+struct UploadQueue {
+    batch_queue: VecDeque<AnnBatch>,
+    uploader_queue: VecDeque<Arc<Condvar>>,
+}
+
 struct Handler {
     tip: Mutex<AnnBatch>,
     url: Arc<String>,
-    queue: Arc<Mutex<VecDeque<AnnBatch>>>,
+    queue: Arc<Mutex<UploadQueue>>,
     shutdown: AtomicBool,
 }
 
@@ -174,7 +178,10 @@ fn update_work_cycle(am: &AnnMine, p: &Arc<Pool>, update: PoolUpdate) -> Vec<Arc
         }
         changes = true;
         info!("Adding handler {}", url);
-        let queue = Arc::new(Mutex::new(VecDeque::new()));
+        let queue = Arc::new(Mutex::new(UploadQueue {
+            batch_queue: VecDeque::new(),
+            uploader_queue: VecDeque::new(),
+        }));
         let h = Arc::new(Handler {
             queue: queue,
             tip: Mutex::new(AnnBatch {
@@ -290,7 +297,11 @@ async fn update_work_loop(am: &AnnMine, p: Arc<Pool>) {
             continue;
         };
         for to_shutdown in update_work_cycle(am, &p, update) {
+            let mut queue = to_shutdown.queue.lock().unwrap();
             to_shutdown.shutdown.store(true, Ordering::Relaxed);
+            for uploader in queue.uploader_queue.drain(..) {
+                uploader.notify_one();
+            }
         }
     }
 }
@@ -322,15 +333,18 @@ fn submit_anns(
         }
     }
     let mut queue = h.queue.lock().unwrap();
-    trace!("Queue {} anns at {} for {}, {} batches currently queued", tip.anns.len(), tip.parent_block_height, h.url, queue.len());
-    if queue.len() >= UPLOAD_CHANNEL_LEN {
-        let front = queue.pop_front();
+    trace!("Queue {} anns at {} for {}, {} batches currently queued", tip.anns.len(), tip.parent_block_height, h.url, queue.batch_queue.len());
+    if queue.batch_queue.len() >= UPLOAD_CHANNEL_LEN {
+        let front = queue.batch_queue.pop_front();
         if let Some(lost_batch) = front {
             p.lost_anns.fetch_add(lost_batch.anns.len(), Ordering::Relaxed);
             debug!("Dropping {} anns @ {} for {}", lost_batch.anns.len(), lost_batch.parent_block_height, h.url);
         }
     }
-    queue.push_back(tip);
+    queue.batch_queue.push_back(tip);
+    if let Some(uploader) = queue.uploader_queue.pop_back() {
+        uploader.notify_one();
+    }
 }
 
 fn submit_to_pool(p: &Pool, ann_struct: &AnnResult, now: u64) {
@@ -600,39 +614,42 @@ async fn uploader_loop(am: &AnnMine, p: Arc<Pool>, h: Arc<Handler>) {
         .timeout(Duration::from_secs(am.cfg.upload_timeout as u64))
         .build()
         .unwrap();
+    let trigger = Arc::new(Condvar::new());
     loop {
-        if h.shutdown.load(Ordering::Relaxed) {
-            break;
-        }
-        let batch = {
+        let batch;
+        {
             let mut queue = h.queue.lock().unwrap();
-            queue.pop_back()
+            loop {
+                if h.shutdown.load(Ordering::Relaxed) {
+                    debug!("Uploader for {} shutting down", h.url);
+                    return;
+                }
+                let maybe_batch = queue.batch_queue.pop_back();
+                if let Some(yes_batch) = maybe_batch {
+                    batch = yes_batch;
+                    break;
+                }
+                queue.uploader_queue.push_back(Arc::clone(&trigger));
+                queue = trigger.wait(queue).unwrap();
+            }
         };
-        match batch {
-            Some(batch) => {
-                let upload_n = am
-                    .upload_num
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let count = batch.anns.len();
-                p.inflight_anns.fetch_add(count, Ordering::Relaxed);
-                match upload_batch(am, &client, batch, &h.url, upload_n, &p).await {
-                    Ok(_) => (),
-                    Err(e) => {
-                        warn!(
-                            "[{}] Error uploading ann batch to {}: {}",
-                            upload_n, h.url, e
-                        );
-                        p.lost_anns.fetch_add(count, Ordering::Relaxed);
-                    }
-                };
-                p.inflight_anns.fetch_sub(count, Ordering::Relaxed);
+        let upload_n = am
+            .upload_num
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let count = batch.anns.len();
+        p.inflight_anns.fetch_add(count, Ordering::Relaxed);
+        match upload_batch(am, &client, batch, &h.url, upload_n, &p).await {
+            Ok(_) => (),
+            Err(e) => {
+                warn!(
+                    "[{}] Error uploading ann batch to {}: {}",
+                    upload_n, h.url, e
+                );
+                p.lost_anns.fetch_add(count, Ordering::Relaxed);
             }
-            None => {
-                util::sleep_ms(10).await;
-            }
-        }
+        };
+        p.inflight_anns.fetch_sub(count, Ordering::Relaxed);
     }
-    debug!("Uploader for {} shutting down", h.url);
 }
 
 pub async fn start(am: &AnnMine) -> Result<()> {


### PR DESCRIPTION
Prefer reuse of recently used uploader threads over the semi-random selection that occurs with idle wait loop to improve connection reuse. For miners on a fast connection, this should reduce the number of idle keepalive connections, saving resources on the miner and pool. The configured number of uploaders will behave like an upper limit rather than an absolute number. An added bonus might be that the more aggressive reuse of connections could reduce the number of reconnections and slow-start situations because idle connections keep timing out.